### PR TITLE
add a dependency of protobuf-compiler

### DIFF
--- a/validator-guides/building-from-source.md
+++ b/validator-guides/building-from-source.md
@@ -28,7 +28,7 @@ Verify your installation.
 
 Make sure you have all the necessary dependencies for compiling and running the Creditcoin node software.
 
-`sudo apt install make clang pkg-config libssl-dev build-essential`
+`sudo apt install make clang pkg-config libssl-dev build-essential protobuf-compiler`
 
 You may need to install & configure [Network Time Protocol (NTP) Client](https://en.wikipedia.org/wiki/Network\_Time\_Protocol).
 


### PR DESCRIPTION
When I tried to build tag 2.222.1, it failed due to the absence of protoc.
After installing the protobuf-compiler package on my ubuntu machine, the build was successful.